### PR TITLE
Ensure all returned ids are truthy

### DIFF
--- a/lib/driftless.js
+++ b/lib/driftless.js
@@ -30,7 +30,7 @@ var DEFAULT_CLEAR_TIMEOUT = exports.DEFAULT_CLEAR_TIMEOUT = function DEFAULT_CLE
 };
 
 var timerHandles = {};
-var nextId = 0;
+var nextId = 1;
 
 function tryDriftless(id, opts) {
   var _this = this,

--- a/src/driftless.js
+++ b/src/driftless.js
@@ -7,7 +7,7 @@ export const DEFAULT_SET_TIMEOUT = (...args) => setTimeout(...args);
 export const DEFAULT_CLEAR_TIMEOUT = (...args) => clearTimeout(...args);
 
 const timerHandles = {};
-let nextId = 0;
+let nextId = 1;
 
 function tryDriftless(id, opts) {
   const {


### PR DESCRIPTION
The first `setTimeout` or `setInterval` return 0. `0` is not a truthy value. It can create problems in some cases.